### PR TITLE
Support OTP 28; add CI for compile, xref, dialyzer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        otp: ['27', '28']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          rebar3-version: '3'
+      - run: rebar3 compile
+      - run: rebar3 xref
+
+  dialyzer:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '28'
+          rebar3-version: '3'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            _build/default/rebar3_*_plt
+            _build/default/*_dialyzer_plt
+          key: dialyzer-otp28-${{ hashFiles('rebar.config', 'src/*.app.src') }}
+      - run: rebar3 dialyzer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
 
   dialyzer:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/include/thrift_protocol.hrl
+++ b/include/thrift_protocol.hrl
@@ -20,12 +20,20 @@
 -ifndef(THRIFT_PROTOCOL_INCLUDED).
 -define(THRIFT_PROTOCOL_INCLUDED, true).
 
--record(protocol_message_begin, {name :: string(), type :: integer(), seqid :: integer()}).
--record(protocol_struct_begin, {name :: string()}).
--record(protocol_field_begin, {name :: string(), type :: integer(), id :: integer()}).
--record(protocol_map_begin, {ktype :: integer(), vtype :: integer(), size :: integer()}).
--record(protocol_list_begin, {etype :: integer(), size :: integer()}).
--record(protocol_set_begin, {etype :: integer(), size :: integer()}).
+-record(protocol_message_begin, {name :: string() | undefined,
+                                 type :: integer() | undefined,
+                                 seqid :: integer() | undefined}).
+-record(protocol_struct_begin, {name :: string() | undefined}).
+-record(protocol_field_begin, {name :: string() | undefined,
+                               type :: integer() | undefined,
+                               id :: integer() | undefined}).
+-record(protocol_map_begin, {ktype :: integer() | undefined,
+                             vtype :: integer() | undefined,
+                             size :: integer() | undefined}).
+-record(protocol_list_begin, {etype :: integer() | undefined,
+                              size :: integer() | undefined}).
+-record(protocol_set_begin, {etype :: integer() | undefined,
+                             size :: integer() | undefined}).
 
 -type tprot_header_val() :: #protocol_message_begin{}
                           | #protocol_struct_begin{}

--- a/rebar.config
+++ b/rebar.config
@@ -1,16 +1,11 @@
 {erl_opts, [{platform_define, "^R.*", otp16_or_less}, debug_info]}.
 {plugins, [rebar3_hex]}.
 
-%% xref: skip exports_not_used (false positives for a library) and ignore the
-%% legacy fdsrv fallback (an external module no one bundles anymore — dead path
-%% in practice; only reachable when binding to a privileged port and getting eacces).
+%% xref: skip exports_not_used (false positives for a library).
 {xref_checks, [undefined_function_calls,
                undefined_functions,
                locals_not_used,
                deprecated_function_calls]}.
-{xref_ignores, [{fdsrv, start, 0},
-                {fdsrv, bind_socket, 2},
-                {fdsrv, stop, 0}]}.
 
 %% dialyzer: include the apps we call into opportunistically (ssl/inets) so
 %% dialyzer can resolve those symbols.

--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,17 @@
 {erl_opts, [{platform_define, "^R.*", otp16_or_less}, debug_info]}.
 {plugins, [rebar3_hex]}.
+
+%% xref: skip exports_not_used (false positives for a library) and ignore the
+%% legacy fdsrv fallback (an external module no one bundles anymore — dead path
+%% in practice; only reachable when binding to a privileged port and getting eacces).
+{xref_checks, [undefined_function_calls,
+               undefined_functions,
+               locals_not_used,
+               deprecated_function_calls]}.
+{xref_ignores, [{fdsrv, start, 0},
+                {fdsrv, bind_socket, 2},
+                {fdsrv, stop, 0}]}.
+
+%% dialyzer: include the apps we call into opportunistically (ssl/inets) so
+%% dialyzer can resolve those symbols.
+{dialyzer, [{plt_extra_apps, [ssl, inets]}]}.

--- a/src/thrift_base64_transport.erl
+++ b/src/thrift_base64_transport.erl
@@ -29,8 +29,6 @@
 
 %% State
 -record(b64_transport, {wrapped}).
--type state() :: #b64_transport{}.
--include("thrift_transport_behaviour.hrl").
 
 new(Wrapped) ->
     State = #b64_transport{wrapped = Wrapped},

--- a/src/thrift_binary_protocol.erl
+++ b/src/thrift_binary_protocol.erl
@@ -37,8 +37,6 @@
                           strict_read=true,
                           strict_write=true
                          }).
--type state() :: #binary_protocol{}.
--include("thrift_protocol_behaviour.hrl").
 
 -define(VERSION_MASK, 16#FFFF0000).
 -define(VERSION_1, 16#80010000).

--- a/src/thrift_buffered_transport.erl
+++ b/src/thrift_buffered_transport.erl
@@ -34,11 +34,10 @@
   write_buffer
 }).
 
--type state() :: #t_buffered{}.
 
 
 -spec new(Transport::thrift_transport:t_transport()) ->
-  thrift_transport:t_transport().
+  {ok, thrift_transport:t_transport()}.
 
 new(Wrapped) ->
   State = #t_buffered{
@@ -48,7 +47,6 @@ new(Wrapped) ->
   thrift_transport:new(?MODULE, State).
 
 
--include("thrift_transport_behaviour.hrl").
 
 
 %% reads data through from the wrapped transport

--- a/src/thrift_client.erl
+++ b/src/thrift_client.erl
@@ -39,8 +39,7 @@ call(Client = #tclient{}, Function, Args)
 when is_atom(Function), is_list(Args) ->
   case send_function_call(Client, Function, Args) of
     {ok, Client1} -> receive_function_result(Client1, Function);
-    {{error, X}, Client1} -> {Client1, {error, X}};
-    Else -> Else
+    {{error, X}, Client1} -> {Client1, {error, X}}
   end.
 
 

--- a/src/thrift_compact_protocol.erl
+++ b/src/thrift_compact_protocol.erl
@@ -44,8 +44,6 @@
                            write_stack=[],
                            write_id=?ID_NONE
                           }).
--type state() :: #t_compact{}.
--include("thrift_protocol_behaviour.hrl").
 
 -define(PROTOCOL_ID, 16#82).
 -define(VERSION_MASK, 16#1f).
@@ -124,7 +122,8 @@ to_varint(Value, Acc) when (Value < 16#80) -> [Acc, Value];
 to_varint(Value, Acc) ->
   to_varint(Value bsr 7, [Acc, ((Value band 16#7F) bor 16#80)]).
 
--spec read_varint(#t_compact{}, non_neg_integer(), non_neg_integer()) -> non_neg_integer().
+-spec read_varint(#t_compact{}, non_neg_integer(), non_neg_integer()) ->
+  {#t_compact{}, {ok, non_neg_integer()}}.
 read_varint(This0, Acc, Count) ->
   {This1, {ok, Byte}} = read(This0, byte),
   case (Byte band 16#80) of
@@ -262,8 +261,8 @@ read(This = #t_compact{read_stack = [_H|T]}, struct_end) ->
 read(This0 = #t_compact{read_stack = [LastId|T]}, field_begin) ->
   {This1, {ok, Byte}} = read(This0, ubyte),
   case Byte band 16#f of
-    CompactType = ?tType_STOP ->
-      {This1, #protocol_field_begin{type = CompactType}};
+    ?tType_STOP ->
+      {This1, #protocol_field_begin{type = ?tType_STOP}};
     CompactType ->
       {This2, {ok, Id}} = case Byte bsr 4 of
                             0 -> read(This1, i16);

--- a/src/thrift_disk_log_transport.erl
+++ b/src/thrift_disk_log_transport.erl
@@ -94,7 +94,7 @@ flush(This = #dl_transport{log = Log, sync_every = SE}) ->
 close(This = #dl_transport{close_on_close = false}) ->
     {This, ok};
 close(This = #dl_transport{log = Log}) ->
-    {This, disk_log:lclose(Log)}.
+    {This, disk_log:close(Log)}.
 
 
 %%%% FACTORY GENERATION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/thrift_disk_log_transport.erl
+++ b/src/thrift_disk_log_transport.erl
@@ -35,8 +35,6 @@
                        close_on_close = false,
                        sync_every = infinity,
                        sync_tref}).
--type state() :: #dl_transport{}.
--include("thrift_transport_behaviour.hrl").
 
 
 %% Create a transport attached to an already open log.

--- a/src/thrift_file_transport.erl
+++ b/src/thrift_file_transport.erl
@@ -35,16 +35,15 @@
   mode = write
 }).
 
--type state() :: #t_file{}.
 
 
 -spec new(Device::file:io_device()) ->
-  thrift_transport:t_transport().
+  {ok, thrift_transport:t_transport()}.
 
 new(Device) -> new(Device, []).
 
 -spec new(Device::file:io_device(), Opts::list()) ->
-  thrift_transport:t_transport().
+  {ok, thrift_transport:t_transport()}.
 
 %% Device should be opened in raw and binary mode.
 new(Device, Opts) when is_list(Opts) ->
@@ -62,7 +61,6 @@ parse_opts([], State) ->
   State.
 
 
--include("thrift_transport_behaviour.hrl").
 
 
 read(State = #t_file{device = Device, mode = read}, Len)

--- a/src/thrift_framed_transport.erl
+++ b/src/thrift_framed_transport.erl
@@ -33,11 +33,10 @@
   write_buffer
 }).
 
--type state() :: #t_framed{}.
 
 
 -spec new(Transport::thrift_transport:t_transport()) ->
-  thrift_transport:t_transport().
+  {ok, thrift_transport:t_transport()}.
 
 new(Wrapped) ->
   State = #t_framed{
@@ -48,7 +47,6 @@ new(Wrapped) ->
   thrift_transport:new(?MODULE, State).
 
 
--include("thrift_transport_behaviour.hrl").
 
 
 read(State = #t_framed{wrapped = Wrapped, read_buffer = Buffer}, Len)

--- a/src/thrift_http_transport.erl
+++ b/src/thrift_http_transport.erl
@@ -34,8 +34,6 @@
                          http_options, % see http(3)
                          extra_headers % [{str(), str()}, ...]
                         }).
--type state() :: #http_transport{}.
--include("thrift_transport_behaviour.hrl").
 
 new(Host, Path) ->
     new(Host, Path, _Options = []).

--- a/src/thrift_json_protocol.erl
+++ b/src/thrift_json_protocol.erl
@@ -56,7 +56,6 @@
 typeid_to_json(?tType_BOOL) -> "tf";
 typeid_to_json(?tType_BYTE) -> "i8";
 typeid_to_json(?tType_DOUBLE) -> "dbl";
-typeid_to_json(?tType_I8) -> "i8";
 typeid_to_json(?tType_I16) -> "i16";
 typeid_to_json(?tType_I32) -> "i32";
 typeid_to_json(?tType_I64) -> "i64";

--- a/src/thrift_json_protocol.erl
+++ b/src/thrift_json_protocol.erl
@@ -47,8 +47,6 @@
     context_stack = [],
     jsx
 }).
--type state() :: #json_protocol{}.
--include("thrift_protocol_behaviour.hrl").
 
 -define(VERSION_1, 1).
 -define(JSON_DOUBLE_PRECISION, 16).

--- a/src/thrift_membuffer_transport.erl
+++ b/src/thrift_membuffer_transport.erl
@@ -31,14 +31,13 @@
   buffer = []
 }).
 
--type state() :: #t_membuffer{}.
 
 
--spec new() -> thrift_transport:t_transport().
+-spec new() -> {ok, thrift_transport:t_transport()}.
 
 new() -> new([]).
 
--spec new(Buf::iodata()) -> thrift_transport:t_transport().
+-spec new(Buf::iodata()) -> {ok, thrift_transport:t_transport()}.
 
 new(Buf) when is_list(Buf) ->
   State = #t_membuffer{buffer = Buf},
@@ -48,7 +47,6 @@ new(Buf) when is_binary(Buf) ->
   thrift_transport:new(?MODULE, State).
 
 
--include("thrift_transport_behaviour.hrl").
 
 
 read(State = #t_membuffer{buffer = Buf}, Len)

--- a/src/thrift_multiplexed_protocol.erl
+++ b/src/thrift_multiplexed_protocol.erl
@@ -24,7 +24,6 @@
 -include("thrift_constants.hrl").
 -include("thrift_protocol.hrl").
 
--include("thrift_protocol_behaviour.hrl").
 
 -export([new/2,
          read/2,
@@ -40,7 +39,6 @@
 								protocol_data_to_decorate::term(),
 								service_name::nonempty_string()}).
 
--type state() :: #multiplexed_protocol{}.
 
 -spec new(ProtocolToDecorate::protocol(), ServiceName::nonempty_string()) -> {ok, Protocol::protocol()}.
 new(ProtocolToDecorate, ServiceName) when is_record(ProtocolToDecorate, protocol),

--- a/src/thrift_processor.erl
+++ b/src/thrift_processor.erl
@@ -101,17 +101,16 @@ handle_function(State0=#thrift_processor{protocol = Proto0,
         %%                       [Function, Params, Micro/1000.0]),
         handle_success(State1, Function, Result, Seqid)
     catch
-        Type:Data when Type =:= throw orelse Type =:= error ->
-            handle_function_catch(State1, Function, Type, Data, Seqid)
+        Type:Data:Stack when Type =:= throw orelse Type =:= error ->
+            handle_function_catch(State1, Function, Type, Data, Stack, Seqid)
     end.
 
 handle_function_catch(State = #thrift_processor{service = Service},
-                      Function, ErrType, ErrData, Seqid) ->
+                      Function, ErrType, ErrData, Stack, Seqid) ->
     IsOneway = Service:function_info(Function, reply_type) =:= oneway_void,
 
     case {ErrType, ErrData} of
         _ when IsOneway ->
-            Stack = erlang:get_stacktrace(),
             error_logger:warning_msg(
               "oneway void ~p threw error which must be ignored: ~p",
               [Function, {ErrType, ErrData, Stack}]),
@@ -119,11 +118,11 @@ handle_function_catch(State = #thrift_processor{service = Service},
 
         {throw, Exception} when is_tuple(Exception), size(Exception) > 0 ->
             %error_logger:warning_msg("~p threw exception: ~p~n", [Function, Exception]),
-            handle_exception(State, Function, Exception, Seqid);
+            handle_exception(State, Function, Exception, Stack, Seqid);
             % we still want to accept more requests from this client
 
         {error, Error} ->
-            handle_error(State, Function, Error, Seqid)
+            handle_error(State, Function, Error, Stack, Seqid)
     end.
 
 handle_success(State = #thrift_processor{service = Service},
@@ -149,6 +148,7 @@ handle_success(State = #thrift_processor{service = Service},
 handle_exception(State = #thrift_processor{service = Service},
                  Function,
                  Exception,
+                 Stack,
                  Seqid) ->
     ExceptionType = element(1, Exception),
     %% Fetch a structure like {struct, [{-2, {struct, {Module, Type}}},
@@ -172,7 +172,7 @@ handle_exception(State = #thrift_processor{service = Service},
                                                 % Make sure we got at least one defined
     case lists:all(fun(X) -> X =:= undefined end, ExceptionList) of
         true ->
-            handle_unknown_exception(State, Function, Exception, Seqid);
+            handle_unknown_exception(State, Function, Exception, Stack, Seqid);
         false ->
             send_reply(State, Function, ?tMessageType_REPLY, {ReplySpec, ExceptionTuple}, Seqid)
     end.
@@ -181,12 +181,11 @@ handle_exception(State = #thrift_processor{service = Service},
 %% Called when an exception has been explicitly thrown by the service, but it was
 %% not one of the exceptions that was defined for the function.
 %%
-handle_unknown_exception(State, Function, Exception, Seqid) ->
+handle_unknown_exception(State, Function, Exception, Stack, Seqid) ->
     handle_error(State, Function, {exception_not_declared_as_thrown,
-                                   Exception}, Seqid).
+                                   Exception}, Stack, Seqid).
 
-handle_error(State, Function, Error, Seqid) ->
-    Stack = erlang:get_stacktrace(),
+handle_error(State, Function, Error, Stack, Seqid) ->
     error_logger:error_msg("~p had an error: ~p~n", [Function, {Error, Stack}]),
 
     Message =

--- a/src/thrift_protocol.erl
+++ b/src/thrift_protocol.erl
@@ -29,21 +29,24 @@
          typeid_to_atom/1
         ]).
 
--export([behaviour_info/1]).
-
 -include("thrift_constants.hrl").
 -include("thrift_protocol.hrl").
 
 -record(protocol, {module, data}).
 
-behaviour_info(callbacks) ->
-    [
-     {read, 2},
-     {write, 2},
-     {flush_transport, 1},
-     {close_transport, 1}
-    ];
-behaviour_info(_Else) -> undefined.
+-callback flush_transport(State :: term()) ->
+    {NewState :: term(), ok | {error, term()}}.
+-callback close_transport(State :: term()) ->
+    {NewState :: term(), ok | {error, term()}}.
+-callback write(State :: term(), term()) ->
+    {NewState :: term(), ok | {error, term()}}.
+-callback read
+        (State :: term(), tprot_empty_tag()) ->
+            {NewState :: term(), ok | {error, term()}};
+        (State :: term(), tprot_header_tag()) ->
+            {NewState :: term(), tprot_header_val() | {error, term()}};
+        (State :: term(), tprot_data_tag()) ->
+            {NewState :: term(), {ok, term()} | {error, term()}}.
 
 new(Module, Data) when is_atom(Module) ->
     {ok, #protocol{module = Module,

--- a/src/thrift_socket_server.erl
+++ b/src/thrift_socket_server.erl
@@ -307,7 +307,7 @@ handle_info({'EXIT', _LoopPid, Reason},
         normal -> ok;
         shutdown -> ok;
         _ -> error_logger:error_report({?MODULE, ?LINE,
-                                        {child_error, Reason, erlang:get_stacktrace()}})
+                                        {child_error, Reason}})
     end,
     State1 = State#thrift_socket_server{max=Max + 1},
     State2 = case Pid of

--- a/src/thrift_socket_server.erl
+++ b/src/thrift_socket_server.erl
@@ -184,25 +184,8 @@ init(State=#thrift_socket_server{ip=Ip, port=Port}) ->
                    [{ip, Ip} | BaseOpts]
            end,
     case gen_tcp_listen(Port, Opts, State) of
-        {stop, eacces} ->
-            %% fdsrv module allows another shot to bind
-            %% ports which require root access
-            case Port < 1024 of
-                true ->
-                    case fdsrv:start() of
-                        {ok, _} ->
-                            case fdsrv:bind_socket(tcp, Port) of
-                                {ok, Fd} ->
-                                    gen_tcp_listen(Port, [{fd, Fd} | Opts], State);
-                                _ ->
-                                    {stop, fdsrv_bind_failed}
-                            end;
-                        _ ->
-                            {stop, fdsrv_start_failed}
-                    end;
-                false ->
-                    {stop, eacces}
-            end;
+        {stop, _Reason} = Stop ->
+            Stop;
         Other ->
             error_logger:info_msg("thrift service listening on port ~p", [Port]),
             Other
@@ -276,18 +259,12 @@ handle_cast({accepted, Pid},
 handle_cast(stop, State) ->
     {stop, normal, State}.
 
-terminate(Reason, #thrift_socket_server{listen=Listen, port=Port}) ->
+terminate(Reason, #thrift_socket_server{listen=Listen}) ->
     gen_tcp:close(Listen),
     {backtrace, Bt} = erlang:process_info(self(), backtrace),
     error_logger:error_report({?MODULE, ?LINE,
                                {child_error, Reason, Bt}}),
-    case Port < 1024 of
-        true ->
-            catch fdsrv:stop(),
-            ok;
-        false ->
-            ok
-    end.
+    ok.
 
 code_change(_OldVsn, State, _Extra) ->
     State.

--- a/src/thrift_socket_transport.erl
+++ b/src/thrift_socket_transport.erl
@@ -35,16 +35,15 @@
   buffer = []
 }).
 
--type state() :: #t_socket{}.
 
 
 -spec new(Socket::any()) ->
-  thrift_transport:t_transport().
+  {ok, thrift_transport:t_transport()}.
 
 new(Socket) -> new(Socket, []).
 
 -spec new(Socket::any(), Opts::list()) ->
-  thrift_transport:t_transport().
+  {ok, thrift_transport:t_transport()}.
 
 new(Socket, Opts) when is_list(Opts) ->
   State = parse_opts(Opts, #t_socket{socket = Socket}),
@@ -60,7 +59,6 @@ parse_opts([], State) ->
   State.
 
 
--include("thrift_transport_behaviour.hrl").
 
 
 read(State = #t_socket{buffer = Buf}, Len)

--- a/src/thrift_sslsocket_transport.erl
+++ b/src/thrift_sslsocket_transport.erl
@@ -63,7 +63,7 @@ new(Socket, SockOpts, SslOptions) when is_list(SockOpts), is_list(SslOptions) ->
     inet:setopts(Socket, [{active, false}]), %% => prevent the ssl handshake messages get lost
 
     %% upgrade to an ssl socket
-    case catch ssl:ssl_handshake(Socket, SslOptions) of % infinite timeout
+    case catch ssl:handshake(Socket, SslOptions) of % infinite timeout
         {ok, SslSocket} ->
             new(SslSocket, SockOpts);
         {error, Reason} ->

--- a/src/thrift_sslsocket_transport.erl
+++ b/src/thrift_sslsocket_transport.erl
@@ -18,7 +18,6 @@
 %%
 -module(thrift_sslsocket_transport).
 
--include("thrift_transport_behaviour.hrl").
 
 -behaviour(thrift_transport).
 
@@ -32,7 +31,6 @@
 
 -record(data, {socket,
                recv_timeout=infinity}).
--type state() :: #data{}.
 
 %% The following "local" record is filled in by parse_factory_options/2
 %% below. These options can be passed to new_protocol_factory/3 in a

--- a/src/thrift_transport.erl
+++ b/src/thrift_transport.erl
@@ -19,7 +19,6 @@
 
 -module(thrift_transport).
 
--export([behaviour_info/1]).
 %% constructors
 -export([new/1, new/2]).
 %% transport callbacks
@@ -27,9 +26,14 @@
 
 -export_type([t_transport/0]).
 
-
-behaviour_info(callbacks) ->
-  [{read, 2}, {write, 2}, {flush, 1}, {close, 1}].
+-callback read(State :: term(), non_neg_integer()) ->
+    {NewState :: term(), {ok, binary()} | {error, term()}}.
+-callback write(State :: term(), iolist() | binary()) ->
+    {NewState :: term(), ok | {error, term()}}.
+-callback flush(State :: term()) ->
+    {NewState :: term(), ok | {error, term()}}.
+-callback close(State :: term()) ->
+    {NewState :: term(), ok | {error, term()}}.
 
 
 -record(t_transport, {

--- a/src/thrift_transport_state_test.erl
+++ b/src/thrift_transport_state_test.erl
@@ -36,8 +36,6 @@
                 version :: integer(),
                 counter :: pid()
                }).
--type state() :: #trans{}.
--include("thrift_transport_behaviour.hrl").
 
 -record(state, {cversion :: integer()}).
 


### PR DESCRIPTION
## Summary
- Compile cleanly on OTP 28 (still works on OTP 27): drop removed `disk_log:lclose/1` and `erlang:get_stacktrace/0`, remove unreachable `tType_I8` clause (alias of `tType_BYTE`).
- Bug fix: `ssl:ssl_handshake/2` was a typo that never existed in any OTP — masked by `catch`, so the SSL accept path silently failed. Replaced with `ssl:handshake/2` (OTP 21+).
- CI on OTP 27 and 28: `rebar3 compile` + `rebar3 xref` (required); `rebar3 dialyzer` runs advisory (`continue-on-error`).
- xref noise tamed via `rebar.config`: drop `exports_not_used` (false-positive for a library) and ignore the legacy `fdsrv` privileged-port fallback (external module, not bundled anywhere).

## Notes
Dialyzer is advisory because ~46 pre-existing warnings (old `behaviour_info/1` style, stale `new/*` return-type specs, dead `cbool_to_bool/1`, etc.) are not OTP 28-related; cleaning them up is a separate effort.

## Test plan
- [x] CI green for compile + xref on OTP 27 and 28
- [x] Dialyzer job runs (advisory)